### PR TITLE
Update POM

### DIFF
--- a/src/main/resources/archetype-resources/pom.xml
+++ b/src/main/resources/archetype-resources/pom.xml
@@ -8,8 +8,7 @@
     <name>${artifactId}-${version}</name>
     
     <properties>
-        <maven.compiler.source>11</maven.compiler.source>
-        <maven.compiler.target>11</maven.compiler.target>
+        <maven.compiler.release>11</maven.compiler.release>
         <endorsed.dir>${project.build.directory}/endorsed</endorsed.dir>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <failOnMissingWebXml>false</failOnMissingWebXml>
@@ -30,27 +29,22 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.10.1</version>
                 <configuration>
-                    <source>11</source>
-                    <target>11</target>
-                    <compilerArguments>
-                        <endorseddirs>${endorsed.dir}</endorseddirs>
-                    </compilerArguments>
+                    <compilerArgs>
+                        <args>-Djava.endorsed.dirs=${endorsed.dir}</args>
+                    </compilerArgs>
                 </configuration>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-war-plugin</artifactId>
-                <version>2.3</version>
-                <configuration>
-                    <failOnMissingWebXml>false</failOnMissingWebXml>
-                </configuration>
+                <version>3.3.2</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-dependency-plugin</artifactId>
-                <version>2.6</version>
+                <version>3.3.0</version>
                 <executions>
                     <execution>
                         <phase>validate</phase>


### PR DESCRIPTION
Hi @juneau001, I have some suggestions for the new Jakarta EE 9.1 archetype for you to consider.
Use latest version for the maven plugins:

- maven-dependency-plugin 3.3.0
  - Require Java 1.8 as minimum

- maven-war-plugin 3.3.2 
  - Require Java 1.7 as minimum
  - current version 2.4 does not work with java 15 and up

- maven-compiler-plugin 3.10.1
  - Require Java 1.8 as minimum

- maven.compiler.release
  - Recommended with Java 9+

- failOnMissingWebXml
  - default to false with servelt 3.1+

- compilerArgs instead of compilerArguments
  - compilerArguments is deprecated